### PR TITLE
Webpack watch is now faster by ~1.5s

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "start": "node ./node_modules/better-npm-run start",
     "build": "node ./node_modules/better-npm-run build",
     "dev": "concurrently --kill-others \"npm run watch-lint\" \"npm run watch-client\" \"npm run start-dev\"",
+    "dev-sourcemaps": "concurrently --kill-others \"npm run watch-lint\" \"npm run watch-client-sourcemaps\" \"npm run start-dev\"",
     "start-dev": "node ./node_modules/better-npm-run start-dev",
     "watch-lint": "watch 'npm run lint' ./src",
     "lint": "./node_modules/tslint/bin/tslint 'src/**/*.ts?(x)'",
     "test": "node ./node_modules/better-npm-run test",
     "test-once": "node ./node_modules/better-npm-run test-once",
-    "watch-client": "node ./node_modules/better-npm-run watch-client"
+    "watch-client": "node ./node_modules/better-npm-run watch-client",
+    "watch-client-sourcemaps": "node ./node_modules/better-npm-run watch-client-sourcemaps"
   },
   "repository": {
     "type": "git",
@@ -53,6 +55,16 @@
     "watch-client": {
       "command": "node webpack/webpack-dev-server.js",
       "env": {
+        "WEBPACK_DEVTOOL": "eval",
+        "UV_THREADPOOL_SIZE": 100,
+        "NODE_ENV": "development",
+        "NODE_PATH": "./src"
+      }
+    },
+    "watch-client-sourcemaps": {
+      "command": "node webpack/webpack-dev-server.js",
+      "env": {
+        "WEBPACK_DEVTOOL": "inline-source-map",
         "UV_THREADPOOL_SIZE": 100,
         "NODE_ENV": "development",
         "NODE_PATH": "./src"

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -10,7 +10,7 @@ const WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
 const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('./webpack-isomorphic-tools'));
 
 module.exports = {
-  devtool: 'inline-source-map',
+  devtool: process.env.WEBPACK_DEVTOOL || 'eval',
   context: path.resolve(__dirname, '..'),
   entry: {
     'main': [


### PR DESCRIPTION
https://webpack.github.io/docs/configuration.html#devtool

We now have two options of starting the server in dev mode:

`yarn dev` -- Using `devtool: 'eval'`. It is faster by aprox 1.5s from my tests but spits out compiled code so it would be hard to debug code in the browser.
`yarn dev-sourcemaps` -- Using `devtool: 'inline-source-maps'`. This is the old `yarn dev`. 1.5s slower. Spits out actual code and is easy to debug.