### PR TITLE
Fix am unhandled error when jwt token is not valid

### DIFF
--- a/src/server/repositories/authTokenRepository.ts
+++ b/src/server/repositories/authTokenRepository.ts
@@ -3,52 +3,97 @@ import {decodeToken} from 'server/services/authTokenService';
 
 export async function getAuthorizationCode(tokenValue: string): Promise<IAuthorizationCode> {
   const jwtToken = await decodeToken(tokenValue);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   const code = await db.AuthToken.findOne({where: {id: jwtToken.jti}});
   return code && code.toJSON();
 }
 
 export async function saveAuthorizationCode(authorizationToken: IAuthorizationCode): Promise<void> {
   const jwtToken = await decodeToken(authorizationToken.value);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   authorizationToken.id = jwtToken.jti;
   await db.AuthToken.insertOrUpdate(authorizationToken);
 }
 
 export async function deleteAuthorizationCode(tokenValue: string): Promise<void> {
   const jwtToken = await decodeToken(tokenValue);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   await db.AuthToken.destroy({where: {id: jwtToken.jti}});
 }
 
 export async function getAccessToken(tokenValue: string): Promise<IAccessToken> {
   const jwtToken = await decodeToken(tokenValue);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   const code = await db.AuthToken.findOne({where: {id: jwtToken.jti}});
   return code && code.toJSON();
 }
 
 export async function saveAccessToken(accessToken: IAccessToken): Promise<void> {
   const jwtToken = await decodeToken(accessToken.value);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   accessToken.id = jwtToken.jti;
   await db.AuthToken.insertOrUpdate(accessToken);
 }
 
 export async function deleteAccessToken(tokenValue: string): Promise<void> {
   const jwtToken = await decodeToken(tokenValue);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   await db.AuthToken.destroy({where: {id: jwtToken.jti}});
 }
 
 export async function getRefreshToken(tokenValue: string): Promise<IRefreshToken> {
   const jwtToken = await decodeToken(tokenValue);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   const code = await db.AuthToken.findOne({where: {id: jwtToken.jti}});
   return code && code.toJSON();
 }
 
 export async function saveRefreshToken(refreshToken: IRefreshToken): Promise<void> {
   const jwtToken = await decodeToken(refreshToken.value);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   refreshToken.id = jwtToken.jti;
   await db.AuthToken.insertOrUpdate(refreshToken);
 }
 
 export async function deleteRefreshToken(tokenValue: string): Promise<void> {
   const jwtToken = await decodeToken(tokenValue);
+
+  if (!jwtToken) {
+    return null;
+  }
+
   await db.AuthToken.destroy({where: {id: jwtToken.jti}});
 }
 

--- a/src/server/services/authTokenService.ts
+++ b/src/server/services/authTokenService.ts
@@ -48,7 +48,7 @@ export async function createToken(exp = ACCESS_TOKEN_EXPIRES_IN, sub = ''): Prom
 
 export async function decodeToken(token: string): Promise<IJwtToken> {
   const result = jwt.decode(token, {complete: true, json: true});
-  return result.payload;
+  return result && result.payload;
 }
 
 export async function verifyToken(token: string): Promise<any> {


### PR DESCRIPTION
I discovered that there was a problem when the `jwtToken` when it was null and it was trowing a `500` error code instead of `401` - not authorized. 

In the case when jwt decoding was returning `null`, it was breaking the authentication flow, because you would expect to get `401` for any invalid token.