### PR TITLE
Add scopes filtering based on existing scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "json-loader": "^0.5.4",
     "jsonwebtoken": "^7.2.1",
     "less": "^2.7.2",
+    "lodash": "^4.17.4",
     "lru-memoize": "^1.0.1",
     "material-ui": "^0.16.6",
     "node-sass": "^4.2.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,8 @@ const port = config.get<number>('port');
 const timeToCheckExpiredTokens = config.get<number>('token.timeToCheckExpiredTokens') * 1000;
 
 async function startServer() {
-  await initializeDatabase();
+  const resetTables = false;
+  await initializeDatabase(resetTables);
 
   setInterval(() => {
     deleteExpiredTokens();

--- a/src/server/auth/oauth2Helpers.ts
+++ b/src/server/auth/oauth2Helpers.ts
@@ -6,6 +6,7 @@ import {
   saveRefreshToken,
   deleteAuthorizationCode,
 } from 'server/repositories/authTokenRepository';
+import {getScopesByUserId} from 'server/repositories/scopesRepository';
 import {getUserByEmailAndPassword} from 'server/repositories/userRepository';
 import {
   generateAuthorizationTokenValue,
@@ -24,12 +25,14 @@ interface IAccessTokenResponse {
 
 export async function createAuthorizationToken(clientId: string, userId: string, redirectURI: string, scope: string[]): Promise<IAuthorizationCode> {
   const value = await generateAuthorizationTokenValue(userId);
+  const filteredScopes = await getScopesByUserId(userId, scope);
+
   const authToken: IAuthorizationCode = {
     value,
     clientId,
     redirectURI,
     userId,
-    scope,
+    scope: filteredScopes,
   };
 
   await saveAuthorizationCode(authToken);
@@ -39,13 +42,14 @@ export async function createAuthorizationToken(clientId: string, userId: string,
 export async function createAccessToken(clientId: string, userId: string, scope: string[]): Promise<IAccessToken> {
   const expirationDate = generateAuthTokenExpirationDate();
   const value = await generateAccessTokenValue(userId);
+  const filteredScopes = await getScopesByUserId(userId, scope);
 
   const accessToken: IAccessToken = {
     value,
     expirationDate,
     clientId,
     userId,
-    scope,
+    scope: filteredScopes,
   };
 
   await saveAccessToken(accessToken);
@@ -54,12 +58,13 @@ export async function createAccessToken(clientId: string, userId: string, scope:
 
 export async function createRefreshToken(clientId: string, userId: string, scope: string[]): Promise<IRefreshToken> {
   const value = await generateRefreshTokenValue(userId);
+  const filteredScopes = await getScopesByUserId(userId, scope);
 
   const refreshToken: IRefreshToken = {
     value,
     clientId,
     userId,
-    scope,
+    scope: filteredScopes,
   };
 
   await saveRefreshToken(refreshToken);

--- a/src/server/repositories/scopesRepository.ts
+++ b/src/server/repositories/scopesRepository.ts
@@ -1,0 +1,46 @@
+const union = require('lodash/union');
+const intersection = require('lodash/intersection');
+
+const commonScopes = [
+  'offline_access',
+];
+
+const superAdminScopes = [
+  'superadmin_all',
+];
+
+const companyAdminScopes = [
+  'company_users_read',
+  'company_users_write',
+];
+
+const userScopes = [
+  'something_read',
+  'something_write',
+];
+
+const allScopes = [
+  ...commonScopes,
+  ...superAdminScopes,
+  ...companyAdminScopes,
+  ...userScopes,
+];
+
+export async function getAllScopes(): Promise<string[]> {
+  return allScopes;
+}
+
+export async function getScopesByUserId(userId: string, scopes: string[] = []): Promise<string[]> {
+  // TODO: This will return the scopes the user has access to, which will be stored in the database
+  // For convenience now we return all scopes.
+  const currentUserScopes = allScopes;
+
+  // If the user request contains any common scopes, add them to the user allowed scopes
+  const totalUserAllowedScopes = union(currentUserScopes, intersection(commonScopes, scopes));
+
+  if (scopes.includes('*')) {
+    return totalUserAllowedScopes;
+  }
+
+  return intersection(totalUserAllowedScopes, scopes);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4359,7 +4359,7 @@ lodash@4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.12.0.tgz#2bd6dc46a040f59e686c972ed21d93dc59053258"
 
-lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@^4.9.0:
+lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@^4.9.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Add basic logic to validate oauth scopes.

To investigate for the future, google uses url based scopes, investigate why. Eg: 
https://developers.google.com/identity/protocols/googlescopes